### PR TITLE
Add Joke Query Controller and Tests

### DIFF
--- a/src/main/java/edu/ucsb/cs156/spring/backenddemo/controllers/JokeController.java
+++ b/src/main/java/edu/ucsb/cs156/spring/backenddemo/controllers/JokeController.java
@@ -1,8 +1,47 @@
 package edu.ucsb.cs156.spring.backenddemo.controllers;
 
-import org.springframework.web.bind.annotation.RestController;
+import edu.ucsb.cs156.spring.backenddemo.services.JokeQueryService;
+import lombok.extern.slf4j.Slf4j;
 
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.ResponseEntity;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+
+
+@Tag(name="Jokes from https://v2.jokeapi.dev/")
+@Slf4j
 @RestController
+@RequestMapping("/api/jokes")
 public class JokeController {
+
+    ObjectMapper mapper = new ObjectMapper();
+
+    @Autowired
+    JokeQueryService JokeQueryService;
+
+    @Operation(summary = "Get jokes from a given category and amount", 
+    description = "JSON return format documented here:  https://v2.jokeapi.dev/")
     
+    @GetMapping("/get")
+
+    public ResponseEntity<String> getJokesQuery(
+        @Parameter(name="category", example="Programming") @RequestParam String category,
+        @Parameter(name="numJokes", example="2") @RequestParam String numJokes
+    ) throws JsonProcessingException {
+        log.info("getJokesQuery: category={}, numJokes={}", category,numJokes);
+        String result = JokeQueryService.getJSON(category, numJokes);
+        return ResponseEntity.ok().body(result);
+    }
 }
+

--- a/src/test/java/edu/ucsb/cs156/spring/backenddemo/controllers/JokeControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/spring/backenddemo/controllers/JokeControllerTests.java
@@ -1,0 +1,54 @@
+package edu.ucsb.cs156.spring.backenddemo.controllers;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+
+import edu.ucsb.cs156.spring.backenddemo.services.JokeQueryService;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.times;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+
+@WebMvcTest(value = JokeController.class)
+public class JokeControllerTests {
+    private ObjectMapper mapper = new ObjectMapper();
+    @Autowired
+    private MockMvc mockMvc;
+    @MockBean
+    JokeQueryService mockJokeQueryService;
+
+    @Test
+    public void test_getJokes() throws Exception {
+    
+        String fakeJsonResult="{ \"fake\" : \"result\" }";
+        String category = "Programming";
+        String numJokes = "2";
+
+        when(mockJokeQueryService.getJSON(eq(category),eq(numJokes))).thenReturn(fakeJsonResult);
+
+        String url = String.format("/api/jokes/get?category=%s&numJokes=%s", category, numJokes);
+
+        MvcResult response = mockMvc
+            .perform( get(url).contentType("application/json"))
+            .andExpect(status().isOk()).andReturn();
+
+        String responseString = response.getResponse().getContentAsString();
+
+        assertEquals(fakeJsonResult, responseString);
+    }
+}
+
+


### PR DESCRIPTION

`/api/jokes/get` is the endpoint that can be used to get information about the jokes of particular category

<http://team01-torry051-dev.dokku-08.cs.ucsb.edu/swagger-ui/index.html> 

This is my deployment and you can use this link to test.

Closes #7  
